### PR TITLE
Specify license: Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.futurealoof.com)",
   "name": "tunnel-agent",
+  "license": "Apache-2.0",
   "description": "HTTP proxy tunneling agent. Formerly part of mikeal/request, now a standalone module.",
   "version": "0.4.1",
   "repository": {


### PR DESCRIPTION
Fixes #7 using `Apache-2.0` as the value for `license` because it's the SPDX key appropriate given @mikeal's comment:

> The project is Apache2 licensed.

Why SPDX? See the [new npm guidelines](https://github.com/npm/npm/releases/tag/v2.10.0).
